### PR TITLE
Add the user orders,profile pages with thier actions

### DIFF
--- a/app/user/layout.tsx
+++ b/app/user/layout.tsx
@@ -1,0 +1,41 @@
+import { APP_NAME } from "@/lib/constants";
+import Image from "next/image";
+import Link from "next/link";
+import Menu from "@/components/shared/header/menu";
+import MainNav from "./main-nav";
+
+
+export default function UserLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <>
+    <div className="flex flex-col">
+        <div className="border-b container mx-auto">
+            <div className="flex items-center h-16 px-4">
+                <Link href="/" className="w-22">
+                    <Image
+                        src="/images/logo.png"
+                        width={60}
+                        height={60}
+                        alt={APP_NAME}
+                    />
+                </Link>
+                {/* Main Nav */}
+                <MainNav className="ms-6" />
+                <div className="ml-auto items-center flex space-x-4">
+                    <Menu />
+                </div>
+            </div>
+        </div>
+
+        <div className="flex-1 space-y-4 p-8 pt-8 container mx-auto">
+            {children}
+        </div>
+    </div>
+    </>
+   
+  );
+}

--- a/app/user/main-nav.tsx
+++ b/app/user/main-nav.tsx
@@ -1,0 +1,29 @@
+'use client';
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
+import React from "react"; 
+
+
+const links = [
+    // { href: "/user", label: "Dashboard" },
+    { href: "/user/orders", label: "Orders" },
+    { href: "/user/profile", label: "Profile" },
+];
+
+const MainNav = ({ className, ...props }: React.HTMLAttributes<HTMLElement>) => {
+    const pathname = usePathname();
+    return (
+        <nav className={cn("flex items-center space-x-4 lg:space-x-6", className)} {...props}>
+            {links.map((link) => (
+                <Link key={link.href} href={link.href}
+                    className={cn("text-sm font-medium transition-colors hover:text-primary", pathname.includes(link.href) ? "" : "text-muted-foreground")}
+                >
+                    {link.label}
+                </Link>
+            ))}
+        </nav>
+    );
+}
+ 
+export default MainNav;

--- a/app/user/orders/page.tsx
+++ b/app/user/orders/page.tsx
@@ -1,0 +1,62 @@
+import { Metadata } from "next";
+import { getMyOrders } from "@/lib/actions/order-actions";
+import { formatCurrency, formatDateTime, formatId } from "@/lib/utils";
+import Link from "next/link";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow,  } from "@/components/ui/table";
+
+
+export const metadata: Metadata = {
+    title: 'My Orders',
+    description: 'View and manage your orders',
+}
+
+const OrdersPage = async ( props: { searchParams: Promise<{page: string}>; }) => {
+    const { page } = await props.searchParams;
+    const orders = await getMyOrders({ page: Number(page) || 1 });
+
+    return (
+        <div className="space-y-2">
+            <h1 className="text-2xl font-bold">Orders</h1>
+            <div className="overflow-x-auto">
+                <Table>
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead className="w-[100px]">ID</TableHead>
+                            <TableHead className="w-[100px]">Date</TableHead>
+                            <TableHead className="w-[100px]">Total</TableHead>
+                            <TableHead className="w-[100px]">Paid</TableHead>
+                            <TableHead className="w-[100px]">Delivered</TableHead>
+                            <TableHead className="w-[100px]">Actions</TableHead>
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        {orders.data.map((order) => (
+                            <TableRow key={order.id}>
+                                <TableCell>{formatId(order.id)}</TableCell>
+                                <TableCell>{formatDateTime(order.createdAt).dateTime}</TableCell>
+                                <TableCell>{formatCurrency(order.totalPrice)}</TableCell>
+                                <TableCell>
+                                    {order.isPaid && order.paidAt
+                                        ? formatDateTime(order.paidAt).dateTime
+                                        : "Not Paid"}
+                                </TableCell>
+                                <TableCell>
+                                    {order.isDelivered && order.deliveredAt
+                                        ? formatDateTime(order.deliveredAt).dateTime
+                                        : "Not Delivered"}
+                                </TableCell>
+                                <TableCell>
+                                    <Link href={`/order/${order.id}`} className="text-blue-500 hover:underline">
+                                        View
+                                    </Link>
+                                </TableCell>
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
+            </div>
+        </div>
+    );
+}
+ 
+export default OrdersPage;

--- a/app/user/page.tsx
+++ b/app/user/page.tsx
@@ -1,0 +1,9 @@
+const UserPage = () => {
+    return (
+        <div>
+            <h1>User Dashboard</h1>
+        </div>
+    );
+}
+ 
+export default UserPage;

--- a/app/user/profile/page.tsx
+++ b/app/user/profile/page.tsx
@@ -1,0 +1,9 @@
+const UserProfilePage = () => {
+    return (
+        <div>
+            <h1>User Profile</h1>
+        </div>
+    );
+}
+
+export default UserProfilePage;

--- a/components/shared/header/user-button.tsx
+++ b/components/shared/header/user-button.tsx
@@ -45,6 +45,18 @@ const UserButton = async () => {
                     </div>
                 </DropdownMenuLabel>
                 <DropdownMenuSeparator />
+                <DropdownMenuItem>
+                    <Link href="/user/profile" className="w-full">
+                        Profile
+                    </Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem>
+                    <Link href="/user/orders" className="w-full">
+                        Orders
+                    </Link>
+                </DropdownMenuItem>
+
+                <DropdownMenuSeparator />
                 <DropdownMenuItem className="p-0 mb-1">
                     <Button variant="destructive" className="w-full" onClick={signOutUser}>
                         Sign Out

--- a/lib/actions/order-actions.ts
+++ b/lib/actions/order-actions.ts
@@ -10,6 +10,7 @@ import { prisma } from "@/db/prisma";
 import { CartItem, PaymentResult } from "@/types";
 import { paypal } from "../paypal";
 import { revalidatePath } from "next/cache";
+import { PAGE_SIZE } from "../constants";
 
 // Create order and the order items
 export async function createOrder() {
@@ -219,4 +220,27 @@ async function updateOrderToPaid({
     });
 
     if (!updatedOrder) throw new Error("Failed to retrieve updated order");
+}
+
+// Get the users orders
+export async function getMyOrders({limit = PAGE_SIZE, page,}: { limit?: number; page: number; }) {
+    const session = await auth();
+    if (!session) throw new Error("User not authenticated");
+    if (!session.user || !session.user.id) {
+        throw new Error("User ID not found in session");
+    }
+    const data = await prisma.order.findMany({
+        where: { userId: session.user.id },
+        take: limit,
+        skip: (page - 1) * limit,
+        orderBy: { createdAt: "desc" }
+    });
+
+    const dataCount = await prisma.order.count({ where: { userId: session.user.id } });
+
+    return { 
+        data,
+        totalPages: Math.ceil(dataCount / limit), 
+    };
+
 }

--- a/lib/constants/index.ts
+++ b/lib/constants/index.ts
@@ -32,5 +32,7 @@ export const shippingAddressDefaultValues = {
 export const PAYMENT_METHODS = process.env.PAYMENT_METHODS ? process.env.PAYMENT_METHODS.split(", ") : ["PayPal", "Stripe", "Cash on Delivery"];
 export const DEFAULT_PAYMENT_METHOD = process.env.DEFAULT_PAYMENT_METHOD || "PayPal";
 
+export const PAGE_SIZE = Number(process.env.NEXT_PUBLIC_PAGE_SIZE) || 3;
+
 
   


### PR DESCRIPTION
This pull request introduces a new user dashboard section with navigation and order management features. It adds a user-specific layout, navigation menu, and pages for viewing user info and orders. It also implements backend logic to fetch paginated user orders and updates the user dropdown menu to include links to these new pages.

**User Interface and Navigation:**

* Added a new `UserLayout` component (`app/user/layout.tsx`) that provides a consistent layout for user pages, including a header with logo, navigation, and a menu.
* Implemented a `MainNav` component (`app/user/main-nav.tsx`) for user navigation, allowing users to switch between "Orders" and "Profile" pages, with active link highlighting based on the current path.
* Created new user pages: a dashboard (`app/user/page.tsx`), profile (`app/user/profile/page.tsx`), and orders list (`app/user/orders/page.tsx`). The orders page displays order details in a table with data fetched from the backend. [[1]](diffhunk://#diff-5370a871cda51d8702f63510ae0a4c3324f2b1211e047deb7060580f266721a5R1-R9) [[2]](diffhunk://#diff-99a24ae57b29d85108c94136c46b58caab87d8fcb9627eb14d2743346c9beb55R1-R9) [[3]](diffhunk://#diff-260743a55055db8d109dca8ee719307466150ecfc18dab015a9c1536d61d9aa6R1-R62)
* Updated the user dropdown menu (`components/shared/header/user-button.tsx`) to include direct links to the new "Profile" and "Orders" pages.

**Order Data Fetching and Pagination:**

* Added a `getMyOrders` function to `lib/actions/order-actions.ts` to fetch paginated orders for the authenticated user, using a configurable `PAGE_SIZE` constant defined in `lib/constants/index.ts`. [[1]](diffhunk://#diff-81fd27986e29a3e3cc0200fab3596e4cefd418d77823d06b17997239b9f5691eR224-R246) [[2]](diffhunk://#diff-81fd27986e29a3e3cc0200fab3596e4cefd418d77823d06b17997239b9f5691eR13) [[3]](diffhunk://#diff-4a24d0847ff65780bccaa3d3dd21e74e04b365cba3b3f905682b719679d17440R35-R36)