### PR TITLE
fix: Update SSH action version for better compatibility

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
       run: npm run build
       
     - name: Deploy to server
-      uses: appleboy/ssh-action@v0.1.5
+      uses: appleboy/ssh-action@v1.0.3
       with:
         host: ${{ secrets.HOST }}
         username: ${{ secrets.USERNAME }}


### PR DESCRIPTION
- Update appleboy/ssh-action from v0.1.5 to v1.0.3
- SSH keys are now properly configured on server
- SSH authentication working correctly