### PR TITLE
feat: Update deployment workflow for manual trigger and correct path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,15 @@
 name: Deploy to Production
 
 on:
-  push:
-    branches: [ main ]
   workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to deploy to'
+        required: true
+        default: 'production'
+        type: choice
+        options:
+        - production
 
 jobs:
   deploy:
@@ -45,7 +51,7 @@ jobs:
         key: ${{ secrets.SSH_PRIVATE_KEY }}
         port: ${{ secrets.PORT }}
         script: |
-          cd /home/platinumapp/private/Platinum-Shop
+          cd ~/private/Platinum-Shop
           git pull origin main
           
           # Use sureapp to run Node.js commands

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+text.text
+env.production


### PR DESCRIPTION
- Remove automatic deployment on push to main
- Add manual workflow_dispatch trigger with environment selection
- Update deployment path to ~/private/Platinum-Shop as configured by admin
- Require manual execution for better deployment control