### PR TITLE
Add the zod schema and the actions to the user profile part

### DIFF
--- a/lib/actions/user.actions.ts
+++ b/lib/actions/user.actions.ts
@@ -10,7 +10,7 @@ import { cookies } from "next/headers";
 import { shippingAddressSchema, 
     signInFormSchema, 
     signUpFormSchema,
-    paymentMethodSchema
+    paymentMethodSchema,
 } from "../validators";
 import { z } from "zod";
 
@@ -140,3 +140,28 @@ export async function updateUserPaymentMethod(data: z.infer<typeof paymentMethod
     }
 }
 
+// Update user's profile
+export async function updateProfile(user: { name: string; email: string}) {
+    try {
+        const session = await auth();
+        const currentUser = await prisma.user.findFirst({
+            where: { id: session?.user?.id }
+        });
+
+        if (!currentUser) {
+            throw new Error("User not found");
+        }
+
+        await prisma.user.update({
+            where: { id: currentUser.id },
+            data: {
+                name: user.name,
+                email: user.email,
+            }
+        });
+
+        return {success: true, message: "Profile updated successfully"};
+    } catch (error) {
+        return {success: false, message: formatError(error)};
+    }
+}

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -107,3 +107,9 @@ export const paymentResultSchema = z.object({
 })
 
 
+// Schema for updating user profile
+export const updateProfileSchema = z.object({
+    name: z.string().min(3, {message: 'Name must be at least 3 characters long'}),
+    email: z.string().email({message: 'Invalid email address'}),
+});
+


### PR DESCRIPTION
This pull request adds support for updating a user's profile, including both backend logic and input validation. The main changes introduce a new action for updating the user's name and email, along with a corresponding validation schema.

**User profile update functionality:**

* Added a new `updateProfile` function to `user.actions.ts` that updates the user's name and email in the database, including error handling for missing users.
* Introduced a new `updateProfileSchema` in `validators.ts` to validate the name and email fields, ensuring the name is at least 3 characters and the email is valid.

**Minor code style improvements:**

* Added a trailing comma in the import statement for schemas in `user.actions.ts` for consistency.